### PR TITLE
Default messages changed suffix in punyinform 2.8 

### DIFF
--- a/Build/hibernated1.inf
+++ b/Build/hibernated1.inf
@@ -2999,7 +2999,7 @@ Constant SPHEREERROR "Nothing happens. Maybe it doesn't work when you're that cl
 
 [ InvSub;
 	if(child(player) == 0) { PrintMsg(MSG_INVENTORY_EMPTY); rtrue; }
-    PrintMsg(MSG_INVENTORY_SUCCESS);
+    PrintMsg(MSG_INVENTORY_DEFAULT);
 	AfterRoutines();
 
   ! we override the InvSub so we can show a nice fancy upgrade status for Io.
@@ -3015,7 +3015,7 @@ Constant SPHEREERROR "Nothing happens. Maybe it doesn't work when you're that cl
   ! in space, no one hears you scream... err... smell
   if(spacesuit has worn) "In this spacesuit, you smell nothing but yourself.";
 	if(ObjectIsUntouchable(noun)) return;
-	PrintMsg(MSG_SMELL_SUCCESS);
+	PrintMsg(MSG_SMELL_DEFAULT);
 ];
 
 [ FillErrorSub;


### PR DESCRIPTION
https://github.com/johanberntsson/PunyInform/releases/tag/v2_8_release

The `FictionTools/puny` script lists PunyInform 1.2 as the target library, but it was quick work to make the director's cut .inf file compatible with PunyInform 3.0.

I appreciate that Hibernated1 has already been released on all platforms a while ago, and there is little need upstream to move library versions now.  But I've learned a lot from this code and thought I'd pass along a quick fix that may be relevant to others who are learning to work with current releases of PunyInform.